### PR TITLE
script_disable_touchpad.sh - use bash shebang

### DIFF
--- a/script_disable_touchpad.sh
+++ b/script_disable_touchpad.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # credit: https://github.com/lahwaacz/Scripts/blob/master/toggle-touchpad.sh
 


### PR DESCRIPTION
dash/posix shells do not define `[[`, see  https://www.shellcheck.net/wiki/SC3010